### PR TITLE
Add news sentiment analysis using Alpha Vantage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Finance AI Agent
 
-This project implements a simple trading agent using [LangGraph](https://github.com/langchain-ai/langgraph). The agent fetches historical stock data, performs technical analysis, and uses Google Gemini to make a buy/sell/hold decision.
+This project implements a simple trading agent using [LangGraph](https://github.com/langchain-ai/langgraph). The agent fetches historical stock data and recent news sentiment, performs technical and sentiment analysis, and uses Google Gemini to make a buy/sell/hold decision.
 
 ## Folder structure
 
 - `data_sources/` – data fetching nodes
   - `stock_data_fetcher.py` – fetch OHLCV data with yfinance
+  - `news_sentiment_fetcher.py` – fetch recent news and sentiment from Alpha Vantage
 - `analysis/` – analysis nodes
   - `technical_analysis.py` – compute indicators and signals
+  - `sentiment_analysis.py` – summarize news sentiment
 - `decision/` – decision nodes
   - `decision_maker.py` – call Gemini for a decision
 - `run_agent.py` – script to run the agent
@@ -22,6 +24,7 @@ This project implements a simple trading agent using [LangGraph](https://github.
 2. Create a `.env` file with your Gemini API key:
    ```ini
    GEMINI_API_KEY=your-key
+   ALPHAVANTAGE_API_KEY=your-alpha-key
    ```
 
 ## Usage
@@ -32,4 +35,6 @@ Run the agent by providing a stock ticker:
 python run_agent.py AAPL
 ```
 
-The script will fetch one month of historical data for the ticker, compute technical indicators, and ask Gemini for a final decision.
+The script fetches one month of price data along with the last day's news headlines.
+It computes technical indicators and sentiment metrics before asking Gemini for a
+final buy/sell/hold decision with a short explanation.

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,0 +1,8 @@
+from .technical_analysis import compute_indicators, analyze
+from .sentiment_analysis import analyze as analyze_sentiment
+
+__all__ = [
+    'compute_indicators',
+    'analyze',
+    'analyze_sentiment',
+]

--- a/analysis/sentiment_analysis.py
+++ b/analysis/sentiment_analysis.py
@@ -1,0 +1,48 @@
+import logging
+from statistics import mean
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def analyze(feed: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Analyze news sentiment feed and return summary metrics."""
+    try:
+        if not feed:
+            raise ValueError("Empty news feed")
+
+        scores = []
+        headlines = []
+        for item in feed:
+            if 'overall_sentiment_score' in item:
+                try:
+                    scores.append(float(item['overall_sentiment_score']))
+                except (TypeError, ValueError):
+                    continue
+            if 'title' in item:
+                headlines.append(item['title'])
+
+        avg_score = mean(scores) if scores else 0.0
+        tone = 'positive' if avg_score > 0.2 else 'negative' if avg_score < -0.2 else 'neutral'
+
+        trend = 'flat'
+        if len(scores) >= 2:
+            if scores[-1] > scores[0]:
+                trend = 'up'
+            elif scores[-1] < scores[0]:
+                trend = 'down'
+
+        urgency = 'high' if len(feed) > 30 else 'normal'
+        summary = ' | '.join(headlines[:3])
+
+        return {
+            'average_sentiment': avg_score,
+            'tone': tone,
+            'headline_summary': summary,
+            'urgency': urgency,
+            'hype': len(feed),
+            'trend': trend,
+        }
+    except Exception as e:
+        logger.exception("Sentiment analysis failed: %s", e)
+        raise

--- a/config.py
+++ b/config.py
@@ -19,3 +19,16 @@ def get_api_key(env_path: Optional[str] = None) -> str:
     if not key:
         raise ValueError('GEMINI_API_KEY not found in environment')
     return key
+
+
+@lru_cache()
+def get_alpha_vantage_key(env_path: Optional[str] = None) -> str:
+    """Load Alpha Vantage API key from .env file."""
+    env_file = env_path or Path(__file__).resolve().parent / '.env'
+    if Path(env_file).exists():
+        load_dotenv(env_file)
+    from os import getenv
+    key = getenv('ALPHAVANTAGE_API_KEY')
+    if not key:
+        raise ValueError('ALPHAVANTAGE_API_KEY not found in environment')
+    return key

--- a/data_sources/__init__.py
+++ b/data_sources/__init__.py
@@ -1,0 +1,7 @@
+from .stock_data_fetcher import StockDataFetcher
+from .news_sentiment_fetcher import NewsSentimentFetcher
+
+__all__ = [
+    'StockDataFetcher',
+    'NewsSentimentFetcher',
+]

--- a/data_sources/news_sentiment_fetcher.py
+++ b/data_sources/news_sentiment_fetcher.py
@@ -1,0 +1,38 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class NewsSentimentFetcher:
+    """Fetch news and sentiment data using the Alpha Vantage API."""
+
+    def __init__(self, tickers: List[str], api_key: str):
+        self.tickers = tickers
+        self.api_key = api_key
+
+    def fetch(self) -> List[Dict[str, Any]]:
+        """Return a list of news articles with sentiment information."""
+        try:
+            ticker_str = ",".join(self.tickers)
+            logger.info("Fetching news sentiment for %s", ticker_str)
+            time_from = (datetime.utcnow() - timedelta(days=1)).strftime("%Y%m%dT%H%M")
+            params = {
+                "function": "NEWS_SENTIMENT",
+                "tickers": ticker_str,
+                "sort": "LATEST",
+                "limit": 50,
+                "time_from": time_from,
+                "apikey": self.api_key,
+            }
+            response = requests.get("https://www.alphavantage.co/query", params=params, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            feed = data.get("feed", [])
+            return feed
+        except Exception as e:
+            logger.exception("Failed to fetch news sentiment: %s", e)
+            raise

--- a/decision/decision_maker.py
+++ b/decision/decision_maker.py
@@ -15,11 +15,16 @@ class DecisionMaker:
 
     def decide(self, signals: Dict[str, str]) -> str:
         prompt = (
-            "You are a trading assistant. Based on the following technical signals,"
-            " provide a single word recommendation: Buy, Sell, or Hold.\n"
+            "You are a trading assistant. Based on the following analysis signals,"
+            " provide a single word recommendation: Buy, Sell, or Hold, followed by"
+            " a short rationale.\n"
             f"RSI signal: {signals.get('rsi')}\n"
             f"MACD signal: {signals.get('macd')}\n"
             f"Bollinger Bands signal: {signals.get('bb')}\n"
+            f"Average sentiment: {signals.get('average_sentiment')}\n"
+            f"Tone: {signals.get('tone')}\n"
+            f"Urgency: {signals.get('urgency')}\n"
+            f"Trend: {signals.get('trend')}\n"
         )
         try:
             logger.info("Sending prompt to Gemini")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ yfinance
 ta
 google-generativeai
 python-dotenv
+requests


### PR DESCRIPTION
## Summary
- fetch Alpha Vantage news sentiment via `NewsSentimentFetcher`
- analyze headlines with new `sentiment_analysis` module
- include news sentiment in Gemini prompts
- export new modules in `__init__` files
- require `requests` and describe new setup in README
- update agent to fetch news and combine analysis

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `python run_agent.py AAPL` *(fails: GEMINI_API_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fef726834832aa55f1a850ab0ec32