### PR TITLE
Add peer company analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ This project implements a simple trading agent using [LangGraph](https://github.
   - `stock_data_fetcher.py` – fetch OHLCV data with yfinance
   - `news_sentiment_fetcher.py` – fetch recent news and sentiment from Alpha Vantage
   - `insider_data_fetcher.py` – fetch insider transactions and sentiment using the `finnhub-python` client
+  - `peer_data_fetcher.py` – retrieve peer tickers and their raw data
 - `analysis/` – analysis nodes
   - `technical_analysis.py` – compute indicators and signals
   - `sentiment_analysis.py` – summarize news sentiment
   - `insider_analysis.py` – evaluate insider trading activity
+  - `peer_analysis.py` – compare peer stock performance
 - `decision/` – decision nodes
   - `decision_maker.py` – call Gemini for a decision
 - `run_agent.py` – script to run the agent
@@ -79,6 +81,34 @@ Output example:
         "top_execs_involved": ["CEO"],
         "mspr": 0.65,
         "recent_cluster": True
+    }
+}
+```
+
+**peer_data_fetcher**
+
+Input: `ticker` string.
+
+Output example:
+
+```python
+{
+    "peers": ["MSFT", "GOOGL"],
+    "price_data": {"MSFT": DataFrame, "GOOGL": DataFrame},
+    "news": {"MSFT": {...}}
+}
+```
+
+**peer_analysis**
+
+Input: dictionary from `peer_data_fetcher`.
+
+Output example:
+
+```python
+{
+    "peer_table": {
+        "MSFT": {"sentiment": 0.2, "change_1d": 1.5, "change_7d": 3.1, "rsi": 55.4}
     }
 }
 ```

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,10 +1,12 @@
 from .technical_analysis import compute_indicators, analyze
 from .sentiment_analysis import analyze as analyze_sentiment
 from .insider_analysis import analyze as analyze_insider
+from .peer_analysis import analyze as analyze_peers
 
 __all__ = [
     'compute_indicators',
     'analyze',
     'analyze_sentiment',
     'analyze_insider',
+    'analyze_peers',
 ]

--- a/analysis/peer_analysis.py
+++ b/analysis/peer_analysis.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Any, Dict
+
+import pandas as pd
+
+from .technical_analysis import compute_indicators
+
+logger = logging.getLogger(__name__)
+
+
+def analyze(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Analyze peer stocks and return comparison metrics."""
+    try:
+        peers = data.get("peers", [])
+        prices: Dict[str, pd.DataFrame] = data.get("price_data", {})
+        news: Dict[str, Any] = data.get("news", {})
+        table: Dict[str, Dict[str, Any]] = {}
+
+        for peer in peers:
+            df = prices.get(peer)
+            price_change_1d = None
+            price_change_7d = None
+            rsi = None
+            if isinstance(df, pd.DataFrame) and not df.empty:
+                price_col = "Adj Close" if "Adj Close" in df.columns else "Close"
+                if len(df) >= 2:
+                    price_change_1d = float(
+                        (df[price_col].iloc[-1] - df[price_col].iloc[-2])
+                        / df[price_col].iloc[-2]
+                        * 100
+                    )
+                if len(df) >= 8:
+                    price_change_7d = float(
+                        (df[price_col].iloc[-1] - df[price_col].iloc[-8])
+                        / df[price_col].iloc[-8]
+                        * 100
+                    )
+                indicators = compute_indicators(df)
+                rsi = float(indicators["RSI_14"].iloc[-1])
+
+            sentiment = news.get(peer, {})
+            news_score = 0.0
+            if isinstance(sentiment, dict):
+                try:
+                    news_score = float(sentiment.get("companyNewsScore", 0.0))
+                except (TypeError, ValueError):
+                    news_score = 0.0
+
+            table[peer] = {
+                "sentiment": news_score,
+                "change_1d": price_change_1d,
+                "change_7d": price_change_7d,
+                "rsi": rsi,
+            }
+
+        return {"peer_table": table}
+    except Exception as e:
+        logger.exception("Peer analysis failed: %s", e)
+        raise

--- a/data_sources/__init__.py
+++ b/data_sources/__init__.py
@@ -1,9 +1,11 @@
 from .stock_data_fetcher import StockDataFetcher
 from .news_sentiment_fetcher import NewsSentimentFetcher
 from .insider_data_fetcher import InsiderDataFetcher
+from .peer_data_fetcher import PeerDataFetcher
 
 __all__ = [
     'StockDataFetcher',
     'NewsSentimentFetcher',
     'InsiderDataFetcher',
+    'PeerDataFetcher',
 ]

--- a/data_sources/peer_data_fetcher.py
+++ b/data_sources/peer_data_fetcher.py
@@ -1,0 +1,56 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import yfinance as yf
+import finnhub
+
+logger = logging.getLogger(__name__)
+
+
+class PeerDataFetcher:
+    """Fetch peer tickers and related data."""
+
+    def __init__(
+        self,
+        ticker: str,
+        api_key: str,
+        base_date: Optional[datetime] = None,
+        limit: int = 3,
+    ):
+        self.ticker = ticker
+        self.api_key = api_key
+        self.base_date = base_date or datetime.now(timezone.utc)
+        self.limit = limit
+        self.client = finnhub.Client(api_key=api_key)
+
+    def fetch(self) -> Dict[str, Any]:
+        """Return peer list, recent price data and news sentiment."""
+        peers: List[str] = []
+        try:
+            peers = self.client.company_peers(self.ticker)[: self.limit]
+        except Exception as e:
+            logger.exception("Error fetching peers: %s", e)
+
+        price_data: Dict[str, pd.DataFrame] = {}
+        news: Dict[str, Any] = {}
+        for peer in peers:
+            try:
+                start = (self.base_date - timedelta(days=10)).strftime("%Y-%m-%d")
+                end = self.base_date.strftime("%Y-%m-%d")
+                df = yf.download(
+                    peer, start=start, end=end, interval="1d", auto_adjust=True
+                )
+                price_data[peer] = df
+            except Exception as e:
+                logger.exception("Error fetching prices for %s: %s", peer, e)
+                price_data[peer] = pd.DataFrame()
+
+            try:
+                news[peer] = self.client.news_sentiment(peer)
+            except Exception as e:
+                logger.exception("Error fetching news sentiment for %s: %s", peer, e)
+                news[peer] = {}
+
+        return {"peers": peers, "price_data": price_data, "news": news}

--- a/run_agent.py
+++ b/run_agent.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TypedDict, Dict, Any, List
 
 import pandas as pd
@@ -9,9 +9,11 @@ from langgraph.graph import StateGraph, END
 from data_sources.stock_data_fetcher import StockDataFetcher
 from data_sources.news_sentiment_fetcher import NewsSentimentFetcher
 from data_sources.insider_data_fetcher import InsiderDataFetcher
+from data_sources.peer_data_fetcher import PeerDataFetcher
 from analysis.technical_analysis import compute_indicators, analyze
 from analysis.sentiment_analysis import analyze as analyze_sentiment
 from analysis.insider_analysis import analyze as analyze_insider
+from analysis.peer_analysis import analyze as analyze_peers
 from decision.decision_maker import DecisionMaker
 from config import get_api_key, get_alpha_vantage_key, get_finnhub_key
 
@@ -20,17 +22,22 @@ class AgentState(TypedDict, total=False):
     data: pd.DataFrame
     news: List[Dict[str, Any]]
     insider: Dict[str, Any]
+    peer_data: Dict[str, Any]
     indicators: pd.DataFrame
     signals: Dict[str, str]
     sentiment: Dict[str, Any]
     insider_insights: Dict[str, Any]
+    peer_insights: Dict[str, Any]
     decision: str
 
 
-def build_graph(ticker: str, gemini_key: str, alpha_key: str, finnhub_key: str, base_date: datetime):
+def build_graph(
+    ticker: str, gemini_key: str, alpha_key: str, finnhub_key: str, base_date: datetime
+):
     fetcher = StockDataFetcher([ticker], end_date=base_date)
     news_fetcher = NewsSentimentFetcher([ticker], alpha_key, base_date=base_date)
     insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
+    peer_fetcher = PeerDataFetcher(ticker, finnhub_key, base_date=base_date)
     decider = DecisionMaker(gemini_key)
 
     def fetch_node(state: AgentState) -> AgentState:
@@ -43,7 +50,6 @@ def build_graph(ticker: str, gemini_key: str, alpha_key: str, finnhub_key: str, 
         print(f"News items: {len(news)}")
         print(f"Insider transactions: {len(insider.get('insider_transactions', []))}")
         print()
-
 
         return {"data": data, "news": news, "insider": insider}
 
@@ -66,11 +72,30 @@ def build_graph(ticker: str, gemini_key: str, alpha_key: str, finnhub_key: str, 
             "insider_insights": insider_insights,
         }
 
+    def peer_fetch_node(state: AgentState) -> AgentState:
+        peer_data = peer_fetcher.fetch()
+
+        print("\n=== Peer Fetch Node ===")
+        print(f"Peers: {peer_data.get('peers')}")
+        print()
+
+        return {"peer_data": peer_data}
+
+    def peer_analysis_node(state: AgentState) -> AgentState:
+        insights = analyze_peers(state["peer_data"])
+
+        print("\n=== Peer Analysis Node ===")
+        print(f"Peer table: {insights.get('peer_table')}")
+        print()
+
+        return {"peer_insights": insights}
+
     def decision_node(state: AgentState) -> AgentState:
         combined = {
             **state.get("signals", {}),
             **state.get("sentiment", {}),
             **state.get("insider_insights", {}),
+            **state.get("peer_insights", {}),
         }
         decision = decider.decide(combined)
 
@@ -83,10 +108,14 @@ def build_graph(ticker: str, gemini_key: str, alpha_key: str, finnhub_key: str, 
     graph = StateGraph(AgentState)
     graph.add_node("fetch", fetch_node)
     graph.add_node("analyze", analysis_node)
+    graph.add_node("peer_fetch", peer_fetch_node)
+    graph.add_node("peer_analyze", peer_analysis_node)
     graph.add_node("decide", decision_node)
 
     graph.add_edge("fetch", "analyze")
-    graph.add_edge("analyze", "decide")
+    graph.add_edge("analyze", "peer_fetch")
+    graph.add_edge("peer_fetch", "peer_analyze")
+    graph.add_edge("peer_analyze", "decide")
     graph.add_edge("decide", END)
 
     graph.set_entry_point("fetch")
@@ -106,7 +135,11 @@ def main():
     gemini_key = get_api_key()
     alpha_key = get_alpha_vantage_key()
     finnhub_key = get_finnhub_key()
-    base_date = datetime.strptime(args.date, "%Y-%m-%d") if args.date else datetime.utcnow()
+    base_date = (
+        datetime.strptime(args.date, "%Y-%m-%d")
+        if args.date
+        else datetime.now(timezone.utc)
+    )
     graph = build_graph(args.ticker, gemini_key, alpha_key, finnhub_key, base_date)
     result = graph.invoke({})
     print("Decision:", result["decision"])


### PR DESCRIPTION
## Summary
- add PeerDataFetcher and PeerAnalysis modules
- integrate peer comparison nodes in run_agent
- extend decision maker prompt with peer details
- document new modules in README
- fix peer data formatting bug and timezone handling

## Testing
- `pip install -r requirements.txt`
- `python run_agent.py AAPL --date 2024-05-01` *(fails: GEMINI_API_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ef273298832aa2006dd3126f217c