### PR TITLE
Use AlphaVantage for peer news sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project implements a simple trading agent using [LangGraph](https://github.
   - `stock_data_fetcher.py` – fetch OHLCV data with yfinance
   - `news_sentiment_fetcher.py` – fetch recent news and sentiment from Alpha Vantage
   - `insider_data_fetcher.py` – fetch insider transactions and sentiment using the `finnhub-python` client
-  - `peer_data_fetcher.py` – retrieve peer tickers and their raw data
+  - `peer_data_fetcher.py` – retrieve peer tickers, price data, and news sentiment via Alpha Vantage
 - `analysis/` – analysis nodes
   - `technical_analysis.py` – compute indicators and signals
   - `sentiment_analysis.py` – summarize news sentiment

--- a/run_agent.py
+++ b/run_agent.py
@@ -37,7 +37,7 @@ def build_graph(
     fetcher = StockDataFetcher([ticker], end_date=base_date)
     news_fetcher = NewsSentimentFetcher([ticker], alpha_key, base_date=base_date)
     insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
-    peer_fetcher = PeerDataFetcher(ticker, finnhub_key, base_date=base_date)
+    peer_fetcher = PeerDataFetcher(ticker, finnhub_key, alpha_key, base_date=base_date)
     decider = DecisionMaker(gemini_key)
 
     def fetch_node(state: AgentState) -> AgentState:


### PR DESCRIPTION
## Summary
- update `peer_data_fetcher` to pull news sentiment via Alpha Vantage
- pass Alpha Vantage key when creating `PeerDataFetcher`
- document the change in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873fe06f710832a8082e1f3a168c813