### PR TITLE
Add SEC filing analysis with caching

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -2,6 +2,7 @@ from .technical_analysis import compute_indicators, analyze
 from .sentiment_analysis import analyze as analyze_sentiment
 from .insider_analysis import analyze as analyze_insider
 from .peer_analysis import analyze as analyze_peers
+from .sec_risk_analysis import SECRiskAnalyzer
 
 __all__ = [
     'compute_indicators',
@@ -9,4 +10,5 @@ __all__ = [
     'analyze_sentiment',
     'analyze_insider',
     'analyze_peers',
+    'SECRiskAnalyzer',
 ]

--- a/analysis/sec_risk_analysis.py
+++ b/analysis/sec_risk_analysis.py
@@ -1,0 +1,113 @@
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import google.generativeai as genai
+import pdfplumber
+
+logger = logging.getLogger(__name__)
+
+
+class SECRiskAnalyzer:
+    """Parse SEC filing PDF and summarize key risk sections using an LLM."""
+
+    def __init__(self, api_key: str, model: str = "gemini-2.5-flash") -> None:
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(model)
+        self.analysis_dir = Path("cache/sec_analysis")
+        self.analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    def summarize_text_with_llm(self, text: str) -> str:
+        """Summarize arbitrary text using the configured LLM."""
+        prompt = f"Summarize the following text in a few sentences:\n{text[:4000]}"
+        try:
+            resp = self.model.generate_content(prompt)
+            return resp.text.strip()
+        except Exception as exc:
+            logger.exception("LLM summarization failed: %s", exc)
+            return ""
+
+    def _extract_text(self, pdf_path: Path) -> str:
+        with pdfplumber.open(pdf_path) as pdf:
+            pages = [p.extract_text() or "" for p in pdf.pages]
+        return "\n".join(pages)
+
+    def _parse_sections(self, text: str, form: str) -> Dict[str, str]:
+        """Extract risk factors and MD&A sections based on form type."""
+        sections: Dict[str, str] = {"risk": "", "mdna": ""}
+
+        if form.upper() == "10-K":
+            risk_pat = re.compile(r"item\s*1a[^\n]*risk factors(?P<section>.*?)item\s*1b", re.IGNORECASE | re.DOTALL)
+            mdna_pat = re.compile(r"item\s*7[^\n]*management's discussion and analysis(?P<section>.*?)item\s*8", re.IGNORECASE | re.DOTALL)
+        elif form.upper() == "10-Q":
+            risk_pat = re.compile(r"item\s*1a[^\n]*risk factors(?P<section>.*?)item\s*2", re.IGNORECASE | re.DOTALL)
+            mdna_pat = re.compile(r"item\s*2[^\n]*management's discussion and analysis(?P<section>.*?)item\s*3", re.IGNORECASE | re.DOTALL)
+        else:
+            return sections
+
+        m = risk_pat.search(text)
+        if m:
+            sections["risk"] = m.group("section").strip()
+
+        m = mdna_pat.search(text)
+        if m:
+            sections["mdna"] = m.group("section").strip()
+
+        return sections
+
+    def _analyze_section(self, section: str) -> Dict[str, str]:
+        """Summarize the section and classify its sentiment."""
+        if not section:
+            return {"summary": "", "sentiment": "Neutral", "score": 0.0}
+
+        summary = self.summarize_text_with_llm(section)
+        sentiment = "Neutral"
+        score = 0.0
+
+        prompt = (
+            "Classify the sentiment of the following text as Positive, Neutral, or Negative "
+            "and provide a numeric score between -1 and 1 as JSON with keys sentiment and score.\n"
+            f"Text:\n{summary[:4000]}"
+        )
+        try:
+            resp = self.model.generate_content(prompt)
+            data = json.loads(resp.text)
+            sentiment = data.get("sentiment", "Neutral")
+            score = float(data.get("score", 0.0))
+        except Exception as exc:
+            logger.warning("Sentiment classification failed: %s", exc)
+            if "positive" in summary.lower():
+                sentiment = "Positive"
+            elif "negative" in summary.lower():
+                sentiment = "Negative"
+        return {"summary": summary, "sentiment": sentiment, "score": score}
+
+
+    def analyze(self, meta: Dict[str, str]) -> Dict[str, Any]:
+        """Analyze a downloaded SEC filing and cache the results."""
+        pdf_file = Path("data/sec_reports") / meta["filename"]
+        json_file = self.analysis_dir / f"{meta['ticker']}_{meta['form']}_{meta['filing_date']}.json"
+        if json_file.exists():
+            logger.info("Using cached SEC analysis %s", json_file)
+            return json.loads(json_file.read_text())
+
+        text = self._extract_text(pdf_file)
+        sections = self._parse_sections(text, meta["form"])
+        risk = self._analyze_section(sections.get("risk", ""))
+        mdna = self._analyze_section(sections.get("mdna", ""))
+
+        results = {
+            "ticker": meta["ticker"],
+            "form_type": meta["form"],
+            "report_date": meta["filing_date"],
+            "risk_summary": risk["summary"],
+            "mdna_summary": mdna["summary"],
+            "risk_sentiment": risk["sentiment"],
+            "mdna_sentiment": mdna["sentiment"],
+        }
+
+        json_file.write_text(json.dumps(results, indent=2))
+        return results
+

--- a/data_sources/__init__.py
+++ b/data_sources/__init__.py
@@ -2,10 +2,12 @@ from .stock_data_fetcher import StockDataFetcher
 from .news_sentiment_fetcher import NewsSentimentFetcher
 from .insider_data_fetcher import InsiderDataFetcher
 from .peer_data_fetcher import PeerDataFetcher
+from .sec_fetcher import SECFetcher
 
 __all__ = [
     'StockDataFetcher',
     'NewsSentimentFetcher',
     'InsiderDataFetcher',
     'PeerDataFetcher',
+    'SECFetcher',
 ]

--- a/data_sources/sec_fetcher.py
+++ b/data_sources/sec_fetcher.py
@@ -1,0 +1,163 @@
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from bs4 import BeautifulSoup
+from fpdf import FPDF
+from sec_edgar_downloader import Downloader
+
+logger = logging.getLogger(__name__)
+
+
+class SECFetcher:
+    """Download the latest 10-K or 10-Q filing as a PDF."""
+
+    def __init__(
+        self,
+        ticker: str,
+        company: str = "MyCompany",
+        email: str = "email@example.com",
+        download_dir: Optional[Path] = None,
+    ) -> None:
+        self.ticker = ticker.upper()
+        self.download_dir = Path(download_dir or "data/sec_reports")
+        self.download_dir.mkdir(parents=True, exist_ok=True)
+        self.downloader = Downloader(company, email, str(self.download_dir))
+
+    def _existing_file(self) -> Optional[Path]:
+        pattern = f"{self.ticker}_*_*.pdf"
+        files = sorted(self.download_dir.glob(pattern), reverse=True)
+        return files[0] if files else None
+
+    def _parse_filing_date(self, text: str) -> str:
+        patterns = [
+            r"FILED AS OF DATE:\s*(\d{8})",
+            r"FILING DATE:\s*(\d{4}-\d{2}-\d{2})",
+            r"Filing Date:\s*(\d{4}-\d{2}-\d{2})",
+        ]
+        for pat in patterns:
+            m = re.search(pat, text, re.IGNORECASE)
+            if m:
+                date = m.group(1)
+                if len(date) == 8:
+                    return f"{date[:4]}-{date[4:6]}-{date[6:]}"
+                return date
+        return datetime.utcnow().date().isoformat()
+
+    def _extract_text(self, file_path: Path) -> str:
+        if file_path.suffix.lower() in {".htm", ".html"}:
+            html = file_path.read_text(errors="ignore")
+            soup = BeautifulSoup(html, "html.parser")
+            return soup.get_text("\n")
+        return file_path.read_text(errors="ignore")
+
+    def _download_latest_forms(self) -> None:
+        """Attempt to download the latest 10-K and 10-Q filings."""
+        for form in ("10-K", "10-Q"):
+            try:
+                logger.info("Downloading latest %s for %s", form, self.ticker)
+                self.downloader.get(form, self.ticker, limit=1, download_details=True)
+            except Exception as exc:
+                logger.warning("Download %s failed: %s", form, exc)
+
+    def _latest_local_filing(self) -> Optional[Tuple[str, Path, str]]:
+        """Return (form, path_to_folder, filing_date) for the most recent filing."""
+        filings_root = self.download_dir / "sec-edgar-filings" / self.ticker
+        latest_info: Optional[Tuple[str, Path, str]] = None
+        for form in ("10-K", "10-Q"):
+            form_dir = filings_root / form
+            if not form_dir.exists():
+                continue
+            subdirs = sorted(form_dir.iterdir(), reverse=True)
+            if not subdirs:
+                continue
+            folder = subdirs[0]
+            candidates = list(folder.rglob("*.txt")) + list(folder.rglob("*.htm")) + list(folder.rglob("*.html"))
+            if not candidates:
+                continue
+            text = self._extract_text(candidates[0])
+            filing_date = self._parse_filing_date(text)
+            if latest_info is None or filing_date > latest_info[2]:
+                latest_info = (form, folder, filing_date)
+        return latest_info
+
+    def _text_to_pdf(self, text: str, pdf_path: Path) -> None:
+        pdf = FPDF()
+        pdf.set_auto_page_break(True, margin=15)
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        for line in text.splitlines():
+            pdf.multi_cell(0, 10, line)
+        pdf.output(str(pdf_path))
+
+    def fetch(self) -> Dict[str, str]:
+        """Fetch the latest available 10-K or 10-Q and return metadata."""
+        try:
+            logger.info("Checking for existing SEC report")
+            existing = self._existing_file()
+            if existing:
+                parts = existing.stem.split("_")
+                form = parts[1]
+                filing_date = parts[2]
+                logger.info("Using cached SEC filing %s", existing)
+                return {
+                    "ticker": self.ticker,
+                    "form": form,
+                    "filing_date": filing_date,
+                    "filename": existing.name,
+                }
+
+            self._download_latest_forms()
+        except Exception as e:
+            logger.exception("SEC download failed: %s", e)
+            raise
+
+        try:
+            latest = self._latest_local_filing()
+            if not latest:
+                raise FileNotFoundError("No filing document found")
+
+            form, folder, filing_date = latest
+            pdf_files = list(folder.rglob("*.pdf"))
+            text = ""
+            if pdf_files:
+                pdf_path = pdf_files[0]
+                txt_candidates = list(folder.rglob("*.txt"))
+                if txt_candidates:
+                    text = self._extract_text(txt_candidates[0])
+            else:
+                candidates = list(folder.rglob("*.htm")) + list(folder.rglob("*.html")) + list(folder.rglob("*.txt"))
+                if not candidates:
+                    raise FileNotFoundError("No filing document found")
+                candidate = candidates[0]
+                text = self._extract_text(candidate)
+                pdf_path = folder / "converted.pdf"
+                self._text_to_pdf(text, pdf_path)
+
+            if not text and pdf_path.suffix.lower() != ".pdf":
+                text = self._extract_text(pdf_path)
+
+            target_name = f"{self.ticker}_{form}_{filing_date}.pdf"
+            target_path = self.download_dir / target_name
+            if target_path.exists():
+                logger.info("Using cached SEC filing %s", target_path)
+                return {
+                    "ticker": self.ticker,
+                    "form": form,
+                    "filing_date": filing_date,
+                    "filename": target_name,
+                }
+
+            pdf_path.replace(target_path)
+            return {
+                "ticker": self.ticker,
+                "form": form,
+                "filing_date": filing_date,
+                "filename": target_name,
+            }
+        except Exception as e:
+            logger.exception("Failed to process downloaded filing: %s", e)
+            raise
+

--- a/decision/decision_maker.py
+++ b/decision/decision_maker.py
@@ -35,7 +35,8 @@ class DecisionMaker:
         prompt = (
             "You are a trading assistant. Based on the following analysis signals,"
             " provide a single word recommendation (Buy, Sell, or Hold) followed by"
-            " a short rationale that references technical, news, insider data, and peer comparisons.\n"
+            " a short rationale that references technical, news, insider data, peer comparisons,"
+            " and SEC risk analysis.\n"
             f"RSI signal: {signals.get('rsi')}\n"
             f"MACD signal: {signals.get('macd')}\n"
             f"Bollinger Bands signal: {signals.get('bb')}\n"
@@ -45,6 +46,9 @@ class DecisionMaker:
             f"Trend: {signals.get('trend')}\n"
             f"Insider score: {signals.get('insider_sentiment_score')}\n"
             f"Insider summary: {signals.get('summary')}\n"
+            f"Risk summary: {signals.get('risk_summary')}\n"
+            f"MD&A summary: {signals.get('mdna_summary')}\n"
+            f"Filing age (days): {signals.get('sec_filing_age_days')}\n"
             f"Peer data:\n{peer_summary}\n"
         )
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ google-generativeai
 python-dotenv
 requests
 finnhub-python
+sec-edgar-downloader
+pdfplumber
+beautifulsoup4
+fpdf


### PR DESCRIPTION
## Summary
- implement new SEC fetcher that downloads the most recent 10-K or 10-Q filing
- analyze Risk Factors and MD&A sections with an LLM and cache results
- surface SEC filing age in the decision prompt

## Testing
- `python -m py_compile run_agent.py data_sources/*.py analysis/*.py decision/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68758f5401c8832aa454e0acc38d558a