### PR TITLE
Fix Unicode SEC filing conversion

### DIFF
--- a/data_sources/sec_fetcher.py
+++ b/data_sources/sec_fetcher.py
@@ -90,7 +90,10 @@ class SECFetcher:
         pdf.add_page()
         pdf.set_font("Arial", size=12)
         for line in text.splitlines():
-            pdf.multi_cell(0, 10, line)
+            # FPDF expects latin-1 encoded text. Remove unsupported
+            # characters to avoid UnicodeEncodeError when saving.
+            safe_line = line.encode("latin-1", "ignore").decode("latin-1")
+            pdf.multi_cell(0, 10, safe_line)
         pdf.output(str(pdf_path))
 
     def fetch(self) -> Dict[str, str]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -121,10 +121,7 @@ def build_graph(
             **state.get("peer_insights", {}),
             **{
                 "risk_summary": state.get("sec_analysis", {}).get("risk_summary"),
-                "mdna_summary": state.get("sec_analysis", {}).get("mdna_summary"),=======
-                "risk_summary": state.get("sec_analysis", {}).get("risk_factors", {}).get("summary"),
-                "mdna_summary": state.get("sec_analysis", {}).get("mdna", {}).get("summary"),
-
+                "mdna_summary": state.get("sec_analysis", {}).get("mdna_summary"),
             },
         }
 


### PR DESCRIPTION
## Summary
- handle unicode text when converting SEC filings to PDF
- remove merge artifact from decision node

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875a3957a70832a87065c339189133b