### PR TITLE
Enhance technical analysis signals

### DIFF
--- a/analysis/technical_analysis.py
+++ b/analysis/technical_analysis.py
@@ -8,20 +8,37 @@ logger = logging.getLogger(__name__)
 
 
 def compute_indicators(data: pd.DataFrame) -> pd.DataFrame:
-    """Compute technical indicators and append to dataframe."""
+    """Compute technical indicators for a price dataframe.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        DataFrame containing at least ``High``, ``Low`` and ``Close`` or
+        ``Adj Close`` columns. Can be a regular DataFrame or a DataFrame with a
+        ``MultiIndex`` as returned by ``yfinance`` when requesting multiple
+        tickers.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``data`` with indicator columns appended.
+    """
     try:
         logger.info("Computing technical indicators")
         df = data.copy()
 
         if isinstance(df.columns, pd.MultiIndex):
             # Flatten multiindex by keeping only the price level
-            if 'Adj Close' in df.columns.get_level_values(0) or 'Close' in df.columns.get_level_values(0):
-                df.columns = df.columns.get_level_values(0)
-            elif 'Adj Close' in df.columns.get_level_values(-1) or 'Close' in df.columns.get_level_values(-1):
-                df.columns = df.columns.get_level_values(-1)
+            levels = df.columns.get_level_values(0)
+            if "Adj Close" in levels or "Close" in levels:
+                df.columns = levels
             else:
-                logger.error("Price columns not found in MultiIndex")
-                raise ValueError("Price column missing")
+                levels = df.columns.get_level_values(-1)
+                if "Adj Close" in levels or "Close" in levels:
+                    df.columns = levels
+                else:
+                    logger.error("Price columns not found in MultiIndex")
+                    raise ValueError("Price column missing")
 
         if df.empty:
             logger.error("No data received for indicator computation")
@@ -33,14 +50,32 @@ def compute_indicators(data: pd.DataFrame) -> pd.DataFrame:
             logger.error("Price column not found in data")
             raise ValueError("Price column missing")
 
-        df['SMA_20'] = ta.trend.sma_indicator(df[price_col], window=20)
-        df['RSI_14'] = ta.momentum.rsi(df[price_col], window=14)
-        df['MACD_12_26_9'] = ta.trend.macd(df[price_col])
-        df['MACD_signal'] = ta.trend.macd_signal(df[price_col])
-        df['MACD_diff'] = ta.trend.macd_diff(df[price_col])
+        if "High" not in df.columns or "Low" not in df.columns:
+            logger.error("High/Low columns not found in data")
+            raise ValueError("High/Low column missing")
+
+        # Core indicators over the full window
+        df["SMA_20"] = ta.trend.sma_indicator(df[price_col], window=20)
+        df["MACD_12_26_9"] = ta.trend.macd(df[price_col])
+        df["MACD_signal"] = ta.trend.macd_signal(df[price_col])
+        df["MACD_diff"] = ta.trend.macd_diff(df[price_col])
         bb = ta.volatility.BollingerBands(close=df[price_col], window=20)
-        df['BBL_20'] = bb.bollinger_lband()
-        df['BBH_20'] = bb.bollinger_hband()
+        df["BBL_20"] = bb.bollinger_lband()
+        df["BBH_20"] = bb.bollinger_hband()
+
+        # Fast reacting indicators using shorter windows
+        df["RSI_14"] = ta.momentum.rsi(df[price_col], window=14)
+        atr = ta.volatility.AverageTrueRange(
+            high=df["High"], low=df["Low"], close=df[price_col], window=14
+        )
+        df["ATR_14"] = atr.average_true_range()
+        adx = ta.trend.ADXIndicator(
+            high=df["High"], low=df["Low"], close=df[price_col], window=14
+        )
+        df["ADX_14"] = adx.adx()
+        momentum = ta.momentum.ROCIndicator(df[price_col], window=10)
+        df["Momentum_10"] = momentum.roc()
+
         return df
     except Exception as e:
         logger.exception("Error computing indicators: %s", e)
@@ -48,32 +83,59 @@ def compute_indicators(data: pd.DataFrame) -> pd.DataFrame:
 
 
 def analyze(df: pd.DataFrame) -> Dict[str, str]:
-    """Analyze indicators to derive simple signals."""
+    """Generate a dictionary of trading signals from indicator values."""
     try:
         logger.info("Analyzing data for signals")
-        signal = {}
+
+        if df.empty:
+            raise ValueError("Empty dataframe for analysis")
+
+        signal: Dict[str, str] = {}
         latest = df.iloc[-1]
 
-        price_col = 'Adj Close' if 'Adj Close' in df.columns else 'Close'
+        price_col = "Adj Close" if "Adj Close" in df.columns else "Close"
 
-        if latest['RSI_14'] > 70:
-            signal['rsi'] = 'overbought'
-        elif latest['RSI_14'] < 30:
-            signal['rsi'] = 'oversold'
+        # RSI
+        if latest["RSI_14"] > 70:
+            signal["rsi"] = "overbought"
+        elif latest["RSI_14"] < 30:
+            signal["rsi"] = "oversold"
         else:
-            signal['rsi'] = 'neutral'
+            signal["rsi"] = "neutral"
 
-        if latest['MACD_12_26_9'] > latest['MACD_signal']:
-            signal['macd'] = 'bullish'
+        # MACD
+        if latest["MACD_12_26_9"] > latest["MACD_signal"]:
+            signal["macd"] = "bullish"
         else:
-            signal['macd'] = 'bearish'
+            signal["macd"] = "bearish"
 
-        if latest[price_col] > latest['BBH_20']:
-            signal['bb'] = 'breakout'
-        elif latest[price_col] < latest['BBL_20']:
-            signal['bb'] = 'breakdown'
+        # Bollinger Bands
+        if latest[price_col] > latest["BBH_20"]:
+            signal["bb"] = "breakout"
+        elif latest[price_col] < latest["BBL_20"]:
+            signal["bb"] = "breakdown"
         else:
-            signal['bb'] = 'neutral'
+            signal["bb"] = "neutral"
+
+        # Trend strength from ADX
+        if latest["ADX_14"] > 25:
+            signal["trend_strength"] = "strong"
+        else:
+            signal["trend_strength"] = "weak"
+
+        # Volatility based on ATR
+        atr_avg = df["ATR_14"].mean()
+        if latest["ATR_14"] > atr_avg * 1.5:
+            signal["volatility"] = "high"
+        else:
+            signal["volatility"] = "normal"
+
+        # Momentum based on Rate of Change
+        if latest["Momentum_10"] > 0:
+            signal["momentum"] = "positive"
+        else:
+            signal["momentum"] = "negative"
+
         return signal
     except Exception as e:
         logger.exception("Error analyzing data: %s", e)

--- a/data_sources/stock_data_fetcher.py
+++ b/data_sources/stock_data_fetcher.py
@@ -13,6 +13,20 @@ class StockDataFetcher:
     """Fetch historical OHLCV data for given tickers."""
 
     def __init__(self, tickers: List[str], lookback_days: int = 30, interval: str = "1d", end_date: Optional[datetime] = None):
+        """Initialize the fetcher.
+
+        Parameters
+        ----------
+        tickers : List[str]
+            Tickers to download.
+        lookback_days : int, optional
+            Number of days of data to retrieve, by default 30.
+        interval : str, optional
+            Data granularity, by default "1d".
+        end_date : datetime, optional
+            Final date for the series. Defaults to ``datetime.utcnow()``.
+        """
+
         self.tickers = tickers
         self.lookback_days = lookback_days
         self.interval = interval
@@ -25,6 +39,7 @@ class StockDataFetcher:
 
             start = (self.end_date - timedelta(days=self.lookback_days)).strftime("%Y-%m-%d")
             end = self.end_date.strftime("%Y-%m-%d")
+
             data = yf.download(
                 self.tickers,
                 start=start,
@@ -33,6 +48,17 @@ class StockDataFetcher:
                 group_by="column",
                 auto_adjust=True,
             )
+
+            if data.empty:
+                logger.error("No data returned from yfinance")
+                raise ValueError("Empty data returned")
+
+            # Ensure expected price columns exist
+            cols = data.columns if not isinstance(data.columns, pd.MultiIndex) else data.columns.get_level_values(0)
+            if "Close" not in cols and "Adj Close" not in cols:
+                logger.error("Price columns missing in fetched data")
+                raise ValueError("Price column missing")
+
             return data
         except Exception as e:
             logger.exception("Failed to fetch data: %s", e)

--- a/tests/test_technical_analysis.py
+++ b/tests/test_technical_analysis.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "analysis" / "technical_analysis.py"
+spec = importlib.util.spec_from_file_location("technical_analysis", MODULE_PATH)
+ta = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ta)
+
+
+def _sample_data():
+    dates = pd.date_range("2024-01-01", periods=30, freq="D")
+    data = pd.DataFrame({
+        "Open": range(1, 31),
+        "High": range(2, 32),
+        "Low": range(1, 31),
+        "Close": range(1, 31),
+        "Volume": range(100, 130)
+    }, index=dates)
+    return data
+
+
+def test_compute_indicators_adds_columns():
+    df = _sample_data()
+    result = ta.compute_indicators(df)
+    expected = {
+        "SMA_20",
+        "MACD_12_26_9",
+        "MACD_signal",
+        "MACD_diff",
+        "BBL_20",
+        "BBH_20",
+        "RSI_14",
+        "ATR_14",
+        "ADX_14",
+        "Momentum_10",
+    }
+    assert expected.issubset(result.columns)
+
+
+def test_analyze_returns_all_signals():
+    df = ta.compute_indicators(_sample_data())
+    signals = ta.analyze(df)
+    assert set(signals.keys()) == {
+        "rsi",
+        "macd",
+        "bb",
+        "trend_strength",
+        "volatility",
+        "momentum",
+    }


### PR DESCRIPTION
## Summary
- add validation to StockDataFetcher and document parameters
- expand compute_indicators with more indicators and error checks
- upgrade analyse() to produce detailed signal dictionary
- add unit tests for technical analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd99a1a40832aba9808c880164323