### PR TITLE
Add cached backtest usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,28 @@ Output example:
     }
 }
 ```
+
+## Cached backtesting
+
+The script `cached_backtest_runner.py` runs the full pipeline over a date range
+while caching all Alpha Vantage news responses and the resulting sentiment
+analysis. Cached files are stored under `data/news_sentiment/<DATE_RANGE>` and
+`results/news_analysis/<DATE_RANGE>`, where `DATE_RANGE` is the start and end
+date formatted as `YYYYMMDD_YYYYMMDD`.
+
+To backtest a ticker and reuse the cached sentiment for its peers, run:
+
+```bash
+python cached_backtest_runner.py AAPL --start 2024-05-01 --end 2024-05-31
+```
+
+After the first run completes you can run the same command for one of the peer
+tickers. Use the same start and end dates so the cached values are reused:
+
+```bash
+python cached_backtest_runner.py DELL --start 2024-05-01 --end 2024-05-31
+```
+
+Backtest results are written to `results/<TICKER>_<DATE_RANGE>/`. Caches are
+shared across tickers, so once the data for a given day is fetched it can be
+reused without further API calls.

--- a/analysis/cached_sentiment.py
+++ b/analysis/cached_sentiment.py
@@ -1,0 +1,35 @@
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .sentiment_analysis import analyze
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_with_cache(
+    ticker: str,
+    feed: List[Dict[str, Any]],
+    base_date: datetime,
+    cache_dir: str | Path = "results/news_analysis",
+) -> Dict[str, Any]:
+    """Return sentiment analysis using a cache to avoid recomputation."""
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+    file_path = cache_path / f"{ticker}_{base_date.strftime('%Y%m%d')}.json"
+
+    if file_path.exists():
+        try:
+            return json.loads(file_path.read_text())
+        except Exception:
+            logger.exception("Failed reading cached sentiment %s", file_path)
+
+    result = analyze(feed)
+    try:
+        file_path.write_text(json.dumps(result, indent=2))
+    except Exception:
+        logger.exception("Failed writing cached sentiment %s", file_path)
+    return result
+

--- a/cached_backtest_runner.py
+++ b/cached_backtest_runner.py
@@ -1,0 +1,333 @@
+import argparse
+import csv
+import json
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, TypedDict
+
+import pandas as pd
+import yfinance as yf
+from langgraph.graph import StateGraph, END
+
+from data_sources.stock_data_fetcher import StockDataFetcher
+from data_sources.news_sentiment_fetcher import NewsSentimentFetcher
+from data_sources.insider_data_fetcher import InsiderDataFetcher
+from data_sources.peer_data_fetcher import PeerDataFetcher
+from data_sources.sec_fetcher import SECFetcher
+from analysis.technical_analysis import compute_indicators, analyze
+from analysis.sentiment_analysis import analyze as analyze_sentiment
+from analysis.cached_sentiment import analyze_with_cache
+from analysis.insider_analysis import analyze as analyze_insider
+from analysis.peer_analysis import analyze as analyze_peers
+from analysis.sec_risk_analysis import SECRiskAnalyzer
+from decision.decision_maker import DecisionMaker
+from config import (
+    get_api_key,
+    get_alpha_vantage_key,
+    get_finnhub_key,
+)
+
+
+class AgentState(TypedDict, total=False):
+    data: pd.DataFrame
+    news: List[Dict[str, Any]]
+    insider: Dict[str, Any]
+    peer_data: Dict[str, Any]
+    indicators: pd.DataFrame
+    signals: Dict[str, str]
+    sentiment: Dict[str, Any]
+    insider_insights: Dict[str, Any]
+    peer_insights: Dict[str, Any]
+    sec_meta: Dict[str, Any]
+    sec_analysis: Dict[str, Any]
+    decision: str
+
+
+class SimpleDecisionMaker(DecisionMaker):
+    """DecisionMaker variant that only returns a single word and logs prompts."""
+
+    def decide(self, signals: Dict[str, Any], run_date: datetime) -> str:  # type: ignore[override]
+        peer_table = signals.get("peer_table", {})
+        peer_lines = []
+        for sym, info in peer_table.items():
+            if not info:
+                peer_lines.append(f"{sym}: data unavailable")
+                continue
+
+            def fmt(val: Any) -> str:
+                return f"{float(val):.2f}" if val is not None else "N/A"
+
+            line = (
+                f"{sym}: 1d {fmt(info.get('change_1d'))}% | 7d {fmt(info.get('change_7d'))}% "
+                f"| RSI {fmt(info.get('rsi'))} | Sent {fmt(info.get('sentiment'))}"
+            )
+            peer_lines.append(line)
+
+        peer_summary = "\n".join(peer_lines)
+        prompt = (
+            "You are a trading assistant. Based on the following analysis signals, "
+            "respond with a single word recommendation: Buy, Sell, or Hold. "
+            "Do not include any rationale or explanation.\n"
+            f"RSI signal: {signals.get('rsi')}\n"
+            f"MACD signal: {signals.get('macd')}\n"
+            f"Bollinger Bands signal: {signals.get('bb')}\n"
+            f"Trend strength: {signals.get('trend_strength')}\n"
+            f"Volatility: {signals.get('volatility')}\n"
+            f"Momentum: {signals.get('momentum')}\n"
+            f"Average sentiment: {signals.get('average_sentiment')}\n"
+            f"Tone: {signals.get('tone')}\n"
+            f"Dominant tone: {signals.get('dominant_tone')}\n"
+            f"Tone distribution: {signals.get('tone_distribution')}\n"
+            f"Headline summary: {signals.get('headline_summary')}\n"
+            f"Urgency: {signals.get('urgency')}\n"
+            f"Hype: {signals.get('hype')}\n"
+            f"Insider score: {signals.get('insider_sentiment_score')}\n"
+            f"Insider summary: {signals.get('summary')}\n"
+            f"Risk summary: {signals.get('risk_summary')}\n"
+            f"Risk sentiment: {signals.get('risk_sentiment')}\n"
+            f"MD&A summary: {signals.get('mdna_summary')}\n"
+            f"MD&A sentiment: {signals.get('mdna_sentiment')}\n"
+            f"Filing age (days): {signals.get('sec_filing_age_days')}\n"
+            f"Highlight headline: {signals.get('highlight_headline')}\n"
+            f"Peer data:\n{peer_summary}\n"
+        )
+        log_file = Path("results") / "gemini_prompts.log"
+        try:
+            log_file.parent.mkdir(exist_ok=True)
+            with log_file.open("a", encoding="utf-8") as f:
+                f.write(f"{run_date.date().isoformat()} | {prompt}\n")
+        except Exception:
+            logging.getLogger(__name__).exception("Failed writing prompt log")
+        try:
+            logging.getLogger(__name__).info("Sending prompt to Gemini")
+            response = self.model.generate_content(prompt)
+            text = response.text.strip()
+            logging.getLogger(__name__).info("Gemini response: %s", text)
+            # only keep the first word
+            word = text.split()[0]
+            return word
+        except Exception as e:
+            logging.getLogger(__name__).exception("Gemini decision failed: %s", e)
+            raise
+
+
+def build_graph(
+    ticker: str,
+    gemini_key: str,
+    alpha_key: str,
+    finnhub_key: str,
+    base_date: datetime,
+    cache_dir: Path,
+    result_dir: Path,
+):
+    fetcher = StockDataFetcher([ticker], end_date=base_date)
+    news_fetcher = NewsSentimentFetcher(
+        [ticker], alpha_key, base_date=base_date, cache_dir=cache_dir
+    )
+    insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
+    peer_fetcher = PeerDataFetcher(
+        ticker,
+        finnhub_key,
+        alpha_key,
+        base_date=base_date,
+        news_cache_dir=str(cache_dir),
+    )
+    sec_fetcher = SECFetcher(ticker)
+    sec_analyzer = SECRiskAnalyzer(gemini_key)
+    decider = SimpleDecisionMaker(gemini_key)
+
+    def fetch_node(state: AgentState) -> AgentState:
+        data = fetcher.fetch()
+        news = news_fetcher.fetch()
+        insider = insider_fetcher.fetch()
+        return {"data": data, "news": news, "insider": insider}
+
+    def analysis_node(state: AgentState) -> AgentState:
+        df = compute_indicators(state["data"])
+        signals = analyze(df)
+        sentiment = analyze_with_cache(ticker, state["news"], base_date, result_dir)
+        insider_insights = analyze_insider(state["insider"])
+        return {
+            "indicators": df,
+            "signals": signals,
+            "sentiment": sentiment,
+            "insider_insights": insider_insights,
+        }
+
+    def sec_fetch_node(state: AgentState) -> AgentState:
+        meta = sec_fetcher.fetch(base_date)
+        return {"sec_meta": meta}
+
+    def sec_analyze_node(state: AgentState) -> AgentState:
+        analysis = sec_analyzer.analyze(state["sec_meta"], base_date)
+        return {"sec_analysis": analysis}
+
+    def peer_fetch_node(state: AgentState) -> AgentState:
+        peer_data = peer_fetcher.fetch()
+        return {"peer_data": peer_data}
+
+    def peer_analysis_node(state: AgentState) -> AgentState:
+        insights = analyze_peers(state["peer_data"])
+        return {"peer_insights": insights}
+
+    def decision_node(state: AgentState) -> AgentState:
+        combined = {
+            **state.get("signals", {}),
+            **state.get("sentiment", {}),
+            **state.get("insider_insights", {}),
+            **state.get("peer_insights", {}),
+            **{
+                "risk_summary": state.get("sec_analysis", {}).get("risk_summary"),
+                "mdna_summary": state.get("sec_analysis", {}).get("mdna_summary"),
+                "risk_sentiment": state.get("sec_analysis", {}).get("risk_sentiment"),
+                "mdna_sentiment": state.get("sec_analysis", {}).get("mdna_sentiment"),
+            },
+        }
+
+        if "sec_meta" in state:
+            try:
+                filing_date = datetime.fromisoformat(state["sec_meta"]["filing_date"])
+                age_days = (base_date.date() - filing_date.date()).days
+                combined["sec_filing_age_days"] = age_days
+            except Exception:
+                pass
+        decision = decider.decide(combined, base_date)
+        return {"decision": decision}
+
+    graph = StateGraph(AgentState)
+    graph.add_node("fetch", fetch_node)
+    graph.add_node("analyze", analysis_node)
+    graph.add_node("sec_fetch", sec_fetch_node)
+    graph.add_node("sec_analyze", sec_analyze_node)
+    graph.add_node("peer_fetch", peer_fetch_node)
+    graph.add_node("peer_analyze", peer_analysis_node)
+    graph.add_node("decide", decision_node)
+
+    graph.add_edge("fetch", "analyze")
+    graph.add_edge("analyze", "sec_fetch")
+    graph.add_edge("sec_fetch", "sec_analyze")
+    graph.add_edge("sec_analyze", "peer_fetch")
+    graph.add_edge("peer_fetch", "peer_analyze")
+    graph.add_edge("peer_analyze", "decide")
+    graph.add_edge("decide", END)
+
+    graph.set_entry_point("fetch")
+    graph.set_finish_point("decide")
+
+    return graph.compile()
+
+
+def get_trading_days(ticker: str, start: datetime, end: datetime) -> pd.DatetimeIndex:
+    """Return trading days between start and end inclusive."""
+    df = yf.download(ticker, start=start.strftime("%Y-%m-%d"), end=(end + timedelta(days=1)).strftime("%Y-%m-%d"), interval="1d", auto_adjust=True)
+    return df.index
+
+
+def run_for_date(
+    ticker: str,
+    day: datetime,
+    keys: Dict[str, str],
+    cache_dir: Path,
+    result_dir: Path,
+) -> str:
+    graph = build_graph(
+        ticker,
+        keys["gemini"],
+        keys["alpha"],
+        keys["finnhub"],
+        day,
+        cache_dir,
+        result_dir,
+    )
+    result = graph.invoke({})
+    decision = str(result["decision"]).strip().split()[0]
+    return decision
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backtest trading agent")
+    parser.add_argument("ticker", help="Ticker symbol to analyze")
+    parser.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", required=True, help="End date YYYY-MM-DD")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    start_date = datetime.strptime(args.start, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    end_date = datetime.strptime(args.end, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+    keys = {
+        "gemini": get_api_key(),
+        "alpha": get_alpha_vantage_key(),
+        "finnhub": get_finnhub_key(),
+    }
+
+    trading_days = get_trading_days(args.ticker, start_date, end_date)
+
+    date_key = f"{start_date.strftime('%Y%m%d')}_{end_date.strftime('%Y%m%d')}"
+    run_key = f"{args.ticker}_{date_key}"
+    cache_dir = Path("data/news_sentiment") / date_key
+    result_dir = Path("results/news_analysis") / date_key
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    result_dir.mkdir(parents=True, exist_ok=True)
+    price_end = end_date + timedelta(days=31)
+    prices = yf.download(
+        args.ticker,
+        start=start_date.strftime("%Y-%m-%d"),
+        end=price_end.strftime("%Y-%m-%d"),
+        interval="1d",
+        auto_adjust=True,
+    )
+
+    price_col = "Close"
+    if "Adj Close" in prices.columns:
+        price_col = "Adj Close"
+
+    dates = list(prices.index)
+
+    out_dir = Path("results") / run_key
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for day in trading_days:
+        logging.info("Running backtest for %s", day.date())
+        decision = run_for_date(
+            args.ticker,
+            day.to_pydatetime().replace(tzinfo=timezone.utc),
+            keys,
+            cache_dir,
+            result_dir,
+        )
+        idx = dates.index(day)
+
+
+        def future_price(offset: int) -> Any:
+            target = idx + offset
+            if target < len(dates):
+                return float(prices.iloc[target][price_col])
+            return None
+
+        row = {
+            "date": day.date().isoformat(),
+            "close_price": float(prices.iloc[idx][price_col]),
+            "prediction": decision,
+            "close_price_1d": future_price(1),
+            "close_price_5d": future_price(5),
+            "close_price_14d": future_price(14),
+            "close_price_30d": future_price(30),
+        }
+
+        month_file = out_dir / f"backtest_results_{day.strftime('%m_%Y')}.csv"
+        write_header = not month_file.exists()
+        with month_file.open("a", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=row.keys())
+            if write_header:
+                writer.writeheader()
+            writer.writerow(row)
+
+        time.sleep(20)
+
+
+if __name__ == "__main__":
+    main()

--- a/data_sources/news_sentiment_fetcher.py
+++ b/data_sources/news_sentiment_fetcher.py
@@ -1,5 +1,7 @@
+import json
 import logging
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -10,15 +12,30 @@ logger = logging.getLogger(__name__)
 class NewsSentimentFetcher:
     """Fetch news and sentiment data using the Alpha Vantage API."""
 
-    def __init__(self, tickers: List[str], api_key: str, base_date: Optional[datetime] = None):
+    def __init__(
+        self,
+        tickers: List[str],
+        api_key: str,
+        base_date: Optional[datetime] = None,
+        cache_dir: Optional[str] = None,
+    ):
         self.tickers = tickers
         self.api_key = api_key
         self.base_date = base_date or datetime.utcnow()
+        self.cache_dir = Path(cache_dir or "data/news_sentiment")
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def fetch(self) -> List[Dict[str, Any]]:
         """Return a list of news articles with sentiment information."""
         try:
             ticker_str = ",".join(self.tickers)
+            date_str = self.base_date.strftime("%Y%m%d")
+            cache_file = self.cache_dir / f"{ticker_str}_{date_str}.json"
+
+            if cache_file.exists():
+                logger.info("Using cached news sentiment for %s", ticker_str)
+                return json.loads(cache_file.read_text())
+
             logger.info("Fetching news sentiment for %s", ticker_str)
             time_from = (self.base_date - timedelta(days=1)).strftime("%Y%m%dT%H%M")
             params = {
@@ -33,6 +50,10 @@ class NewsSentimentFetcher:
             response.raise_for_status()
             data = response.json()
             feed = data.get("feed", [])
+            try:
+                cache_file.write_text(json.dumps(feed))
+            except Exception:
+                logger.exception("Failed writing news cache file %s", cache_file)
             return feed
         except Exception as e:
             logger.exception("Failed to fetch news sentiment: %s", e)

--- a/data_sources/peer_data_fetcher.py
+++ b/data_sources/peer_data_fetcher.py
@@ -1,6 +1,8 @@
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -22,12 +24,16 @@ class PeerDataFetcher:
         alpha_key: str,
         base_date: Optional[datetime] = None,
         limit: int = 3,
+        news_cache_dir: Optional[str] = None,
     ):
         self.ticker = ticker
 
         self.finnhub_key = finnhub_key
         self.alpha_key = alpha_key
         self.base_date = base_date or datetime.now(timezone.utc)
+
+        self.news_cache_dir = Path(news_cache_dir or "data/news_sentiment")
+        self.news_cache_dir.mkdir(parents=True, exist_ok=True)
 
 
         self.limit = limit
@@ -36,6 +42,13 @@ class PeerDataFetcher:
     def _fetch_news_score(self, ticker: str) -> Dict[str, Any]:
         """Fetch news sentiment score for a single ticker using Alpha Vantage."""
         try:
+            date_str = self.base_date.strftime("%Y%m%d")
+            cache_file = self.news_cache_dir / f"{ticker}_{date_str}_score.json"
+
+            if cache_file.exists():
+                logger.info("Using cached news score for %s", ticker)
+                return json.loads(cache_file.read_text())
+
             time_from = (self.base_date - timedelta(days=1)).strftime("%Y%m%dT%H%M")
             params = {
                 "function": "NEWS_SENTIMENT",
@@ -58,7 +71,12 @@ class PeerDataFetcher:
                         except (TypeError, ValueError):
                             continue
             avg_score = sum(scores) / len(scores) if scores else 0.0
-            return {"companyNewsScore": avg_score}
+            result = {"companyNewsScore": avg_score}
+            try:
+                cache_file.write_text(json.dumps(result))
+            except Exception:
+                logger.exception("Failed writing news score cache %s", cache_file)
+            return result
         except Exception as e:
             logger.exception("Error fetching news sentiment for %s: %s", ticker, e)
             return {}
@@ -70,6 +88,9 @@ class PeerDataFetcher:
             peers = self.client.company_peers(self.ticker)[: self.limit]
         except Exception as e:
             logger.exception("Error fetching peers: %s", e)
+
+        if self.ticker not in peers:
+            peers.insert(0, self.ticker)
 
         price_data: Dict[str, pd.DataFrame] = {}
         news: Dict[str, Any] = {}

--- a/run_agent.py
+++ b/run_agent.py
@@ -14,6 +14,7 @@ from data_sources.peer_data_fetcher import PeerDataFetcher
 from data_sources.sec_fetcher import SECFetcher
 from analysis.technical_analysis import compute_indicators, analyze
 from analysis.sentiment_analysis import analyze as analyze_sentiment
+from analysis.cached_sentiment import analyze_with_cache
 from analysis.insider_analysis import analyze as analyze_insider
 from analysis.peer_analysis import analyze as analyze_peers
 from analysis.sec_risk_analysis import SECRiskAnalyzer
@@ -40,7 +41,9 @@ def build_graph(
     ticker: str, gemini_key: str, alpha_key: str, finnhub_key: str, base_date: datetime
 ):
     fetcher = StockDataFetcher([ticker], end_date=base_date)
-    news_fetcher = NewsSentimentFetcher([ticker], alpha_key, base_date=base_date)
+    news_fetcher = NewsSentimentFetcher(
+        [ticker], alpha_key, base_date=base_date, cache_dir="data/news_sentiment"
+    )
     insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
     peer_fetcher = PeerDataFetcher(ticker, finnhub_key, alpha_key, base_date=base_date)
     sec_fetcher = SECFetcher(ticker)
@@ -64,7 +67,7 @@ def build_graph(
     def analysis_node(state: AgentState) -> AgentState:
         df = compute_indicators(state["data"])
         signals = analyze(df)
-        sentiment = analyze_sentiment(state["news"])
+        sentiment = analyze_with_cache(ticker, state["news"], base_date)
         insider_insights = analyze_insider(state["insider"])
 
         print("\n=== Analysis Node ===")


### PR DESCRIPTION
## Summary
- include the target ticker in `PeerDataFetcher` peer results
- share cache directories across tickers in `cached_backtest_runner`
- document how to run cached backtests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b90e97478832a943f9970670db01a