### PR TITLE
Add Finnhub and HuggingFace fallback for news sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project implements a simple trading agent using [LangGraph](https://github.
 - `data_sources/` – data fetching nodes
   - `stock_data_fetcher.py` – fetch OHLCV data with yfinance
   - `news_sentiment_fetcher.py` – fetch recent news and sentiment from Alpha Vantage
+    with Finnhub/HuggingFace fallback
   - `insider_data_fetcher.py` – fetch insider transactions and sentiment using the `finnhub-python` client
   - `peer_data_fetcher.py` – retrieve peer tickers, price data, and news sentiment via Alpha Vantage
 - `analysis/` – analysis nodes
@@ -30,6 +31,7 @@ This project implements a simple trading agent using [LangGraph](https://github.
    GEMINI_API_KEY=your-key
    ALPHAVANTAGE_API_KEY=your-alpha-key
    FINNHUB_API_KEY=your-finnhub-key
+   HUGGINGFACE_API_KEY=your-huggingface-key
    ```
 
 ## Usage

--- a/backtest_runner.py
+++ b/backtest_runner.py
@@ -26,6 +26,7 @@ from config import (
     get_api_key,
     get_alpha_vantage_key,
     get_finnhub_key,
+    get_huggingface_key,
 )
 
 
@@ -117,10 +118,11 @@ def build_graph(
     gemini_key: str,
     alpha_key: str,
     finnhub_key: str,
+    hf_key: str,
     base_date: datetime,
 ):
     fetcher = StockDataFetcher([ticker], end_date=base_date)
-    news_fetcher = NewsSentimentFetcher([ticker], alpha_key, base_date=base_date)
+    news_fetcher = NewsSentimentFetcher([ticker], alpha_key, finnhub_key, hf_key, base_date=base_date)
     insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
     peer_fetcher = PeerDataFetcher(ticker, finnhub_key, alpha_key, base_date=base_date)
     sec_fetcher = SECFetcher(ticker)
@@ -220,6 +222,7 @@ def run_for_date(ticker: str, day: datetime, keys: Dict[str, str]) -> str:
         keys["gemini"],
         keys["alpha"],
         keys["finnhub"],
+        keys["hf"],
         day,
     )
     result = graph.invoke({})
@@ -243,6 +246,7 @@ def main() -> None:
         "gemini": get_api_key(),
         "alpha": get_alpha_vantage_key(),
         "finnhub": get_finnhub_key(),
+        "hf": get_huggingface_key(),
     }
 
     trading_days = get_trading_days(args.ticker, start_date, end_date)

--- a/config.py
+++ b/config.py
@@ -45,3 +45,16 @@ def get_finnhub_key(env_path: Optional[str] = None) -> str:
     if not key:
         raise ValueError('FINNHUB_API_KEY not found in environment')
     return key
+
+
+@lru_cache()
+def get_huggingface_key(env_path: Optional[str] = None) -> str:
+    """Load Hugging Face API key from .env file."""
+    env_file = env_path or Path(__file__).resolve().parent / '.env'
+    if Path(env_file).exists():
+        load_dotenv(env_file)
+    from os import getenv
+    key = getenv('HUGGINGFACE_API_KEY')
+    if not key:
+        raise ValueError('HUGGINGFACE_API_KEY not found in environment')
+    return key

--- a/data_sources/news_sentiment_fetcher.py
+++ b/data_sources/news_sentiment_fetcher.py
@@ -10,51 +10,128 @@ logger = logging.getLogger(__name__)
 
 
 class NewsSentimentFetcher:
-    """Fetch news and sentiment data using the Alpha Vantage API."""
+    """Fetch news and sentiment data.
+
+    Tries Alpha Vantage first and falls back to Finnhub + HuggingFace
+    sentiment analysis when Alpha Vantage fails or returns no data.
+    """
 
     def __init__(
         self,
         tickers: List[str],
-        api_key: str,
+        alpha_key: str,
+        finnhub_key: Optional[str] = None,
+        hf_key: Optional[str] = None,
         base_date: Optional[datetime] = None,
         cache_dir: Optional[str] = None,
     ):
         self.tickers = tickers
-        self.api_key = api_key
+        self.alpha_key = alpha_key
+        self.finnhub_key = finnhub_key
+        self.hf_key = hf_key
         self.base_date = base_date or datetime.utcnow()
         self.cache_dir = Path(cache_dir or "data/news_sentiment")
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
+    def _analyze_text(self, text: str) -> Dict[str, Any]:
+        """Return sentiment score and label for text using HuggingFace."""
+        if not self.hf_key:
+            return {"overall_sentiment_score": 0.0, "overall_sentiment_label": "neutral"}
+        try:
+            headers = {"Authorization": f"Bearer {self.hf_key}"}
+            resp = requests.post(
+                "https://api-inference.huggingface.co/models/ProsusAI/finbert",
+                headers=headers,
+                json={"inputs": text},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            pos = neg = 0.0
+            top_label = "neutral"
+            top_score = 0.0
+            for item in result:
+                label = item.get("label", "").lower()
+                score = float(item.get("score", 0.0))
+                if label == "positive":
+                    pos = score
+                elif label == "negative":
+                    neg = score
+                if score > top_score:
+                    top_score = score
+                    top_label = label
+            overall = pos - neg
+            return {
+                "overall_sentiment_score": overall,
+                "overall_sentiment_label": top_label,
+                "relevance_score": 1.0,
+            }
+        except Exception:
+            logger.exception("HuggingFace sentiment analysis failed")
+            return {"overall_sentiment_score": 0.0, "overall_sentiment_label": "neutral", "relevance_score": 1.0}
+
+    def _fetch_alpha(self, ticker_str: str) -> List[Dict[str, Any]]:
+        time_from = (self.base_date - timedelta(days=1)).strftime("%Y%m%dT%H%M")
+        params = {
+            "function": "NEWS_SENTIMENT",
+            "tickers": ticker_str,
+            "sort": "LATEST",
+            "limit": 50,
+            "time_from": time_from,
+            "apikey": self.alpha_key,
+        }
+        response = requests.get("https://www.alphavantage.co/query", params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        feed = data.get("feed", [])
+        # Alpha Vantage returns "Note" when rate limited
+        if not feed:
+            raise ValueError("Empty Alpha Vantage feed")
+        return feed
+
+    def _fetch_finnhub(self, ticker_str: str) -> List[Dict[str, Any]]:
+        if not self.finnhub_key:
+            return []
+        frm = (self.base_date - timedelta(days=1)).strftime("%Y-%m-%d")
+        to = self.base_date.strftime("%Y-%m-%d")
+        params = {
+            "symbol": ticker_str,
+            "from": frm,
+            "to": to,
+            "token": self.finnhub_key,
+        }
+        resp = requests.get("https://finnhub.io/api/v1/company-news", params=params, timeout=10)
+        resp.raise_for_status()
+        articles = resp.json()[:50]
+        feed: List[Dict[str, Any]] = []
+        for art in articles:
+            title = art.get("headline")
+            if not title:
+                continue
+            sentiment = self._analyze_text(title)
+            feed.append({"title": title, **sentiment})
+        return feed
+
     def fetch(self) -> List[Dict[str, Any]]:
         """Return a list of news articles with sentiment information."""
+        ticker_str = ",".join(self.tickers)
+        date_str = self.base_date.strftime("%Y%m%d")
+        cache_file = self.cache_dir / f"{ticker_str}_{date_str}.json"
+
+        if cache_file.exists():
+            logger.info("Using cached news sentiment for %s", ticker_str)
+            return json.loads(cache_file.read_text())
+
+        # Try Alpha Vantage first
         try:
-            ticker_str = ",".join(self.tickers)
-            date_str = self.base_date.strftime("%Y%m%d")
-            cache_file = self.cache_dir / f"{ticker_str}_{date_str}.json"
-
-            if cache_file.exists():
-                logger.info("Using cached news sentiment for %s", ticker_str)
-                return json.loads(cache_file.read_text())
-
-            logger.info("Fetching news sentiment for %s", ticker_str)
-            time_from = (self.base_date - timedelta(days=1)).strftime("%Y%m%dT%H%M")
-            params = {
-                "function": "NEWS_SENTIMENT",
-                "tickers": ticker_str,
-                "sort": "LATEST",
-                "limit": 50,
-                "time_from": time_from,
-                "apikey": self.api_key,
-            }
-            response = requests.get("https://www.alphavantage.co/query", params=params, timeout=10)
-            response.raise_for_status()
-            data = response.json()
-            feed = data.get("feed", [])
-            try:
-                cache_file.write_text(json.dumps(feed))
-            except Exception:
-                logger.exception("Failed writing news cache file %s", cache_file)
-            return feed
+            logger.info("Fetching news sentiment for %s via Alpha Vantage", ticker_str)
+            feed = self._fetch_alpha(ticker_str)
         except Exception as e:
-            logger.exception("Failed to fetch news sentiment: %s", e)
-            raise
+            logger.warning("Alpha Vantage failed: %s", e)
+            feed = self._fetch_finnhub(ticker_str)
+
+        try:
+            cache_file.write_text(json.dumps(feed))
+        except Exception:
+            logger.exception("Failed writing news cache file %s", cache_file)
+        return feed

--- a/run_agent.py
+++ b/run_agent.py
@@ -19,7 +19,12 @@ from analysis.insider_analysis import analyze as analyze_insider
 from analysis.peer_analysis import analyze as analyze_peers
 from analysis.sec_risk_analysis import SECRiskAnalyzer
 from decision.decision_maker import DecisionMaker
-from config import get_api_key, get_alpha_vantage_key, get_finnhub_key
+from config import (
+    get_api_key,
+    get_alpha_vantage_key,
+    get_finnhub_key,
+    get_huggingface_key,
+)
 
 
 class AgentState(TypedDict, total=False):
@@ -38,11 +43,16 @@ class AgentState(TypedDict, total=False):
 
 
 def build_graph(
-    ticker: str, gemini_key: str, alpha_key: str, finnhub_key: str, base_date: datetime
+    ticker: str,
+    gemini_key: str,
+    alpha_key: str,
+    finnhub_key: str,
+    hf_key: str,
+    base_date: datetime,
 ):
     fetcher = StockDataFetcher([ticker], end_date=base_date)
     news_fetcher = NewsSentimentFetcher(
-        [ticker], alpha_key, base_date=base_date, cache_dir="data/news_sentiment"
+        [ticker], alpha_key, finnhub_key, hf_key, base_date=base_date, cache_dir="data/news_sentiment"
     )
     insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
     peer_fetcher = PeerDataFetcher(ticker, finnhub_key, alpha_key, base_date=base_date)
@@ -176,12 +186,13 @@ def main():
     gemini_key = get_api_key()
     alpha_key = get_alpha_vantage_key()
     finnhub_key = get_finnhub_key()
+    hf_key = get_huggingface_key()
     base_date = (
         datetime.strptime(args.date, "%Y-%m-%d")
         if args.date
         else datetime.now(timezone.utc)
     )
-    graph = build_graph(args.ticker, gemini_key, alpha_key, finnhub_key, base_date)
+    graph = build_graph(args.ticker, gemini_key, alpha_key, finnhub_key, hf_key, base_date)
     result = graph.invoke({})
     print("\nFinal decision:", result["decision"])
 


### PR DESCRIPTION
## Summary
- add Hugging Face API key loader
- fall back to Finnhub news with FinBERT sentiment when Alpha Vantage fails
- wire new sentiment pipeline into backtest and runtime scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68962de13010832a84fe0d09593836e3