### PR TITLE
Use Gemini for news sentiment fallback and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project implements a simple trading agent using [LangGraph](https://github.
 - `data_sources/` – data fetching nodes
   - `stock_data_fetcher.py` – fetch OHLCV data with yfinance
   - `news_sentiment_fetcher.py` – fetch recent news and sentiment from Alpha Vantage
-    with Finnhub/HuggingFace fallback
+    with Finnhub + Gemini fallback
   - `insider_data_fetcher.py` – fetch insider transactions and sentiment using the `finnhub-python` client
   - `peer_data_fetcher.py` – retrieve peer tickers, price data, and news sentiment via Alpha Vantage
 - `analysis/` – analysis nodes
@@ -31,7 +31,6 @@ This project implements a simple trading agent using [LangGraph](https://github.
    GEMINI_API_KEY=your-key
    ALPHAVANTAGE_API_KEY=your-alpha-key
    FINNHUB_API_KEY=your-finnhub-key
-   HUGGINGFACE_API_KEY=your-huggingface-key
    ```
 
 ## Usage

--- a/backtest_runner.py
+++ b/backtest_runner.py
@@ -26,7 +26,6 @@ from config import (
     get_api_key,
     get_alpha_vantage_key,
     get_finnhub_key,
-    get_huggingface_key,
 )
 
 
@@ -118,11 +117,10 @@ def build_graph(
     gemini_key: str,
     alpha_key: str,
     finnhub_key: str,
-    hf_key: str,
     base_date: datetime,
 ):
     fetcher = StockDataFetcher([ticker], end_date=base_date)
-    news_fetcher = NewsSentimentFetcher([ticker], alpha_key, finnhub_key, hf_key, base_date=base_date)
+    news_fetcher = NewsSentimentFetcher([ticker], alpha_key, finnhub_key, gemini_key, base_date=base_date)
     insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
     peer_fetcher = PeerDataFetcher(ticker, finnhub_key, alpha_key, base_date=base_date)
     sec_fetcher = SECFetcher(ticker)
@@ -222,7 +220,6 @@ def run_for_date(ticker: str, day: datetime, keys: Dict[str, str]) -> str:
         keys["gemini"],
         keys["alpha"],
         keys["finnhub"],
-        keys["hf"],
         day,
     )
     result = graph.invoke({})
@@ -246,7 +243,6 @@ def main() -> None:
         "gemini": get_api_key(),
         "alpha": get_alpha_vantage_key(),
         "finnhub": get_finnhub_key(),
-        "hf": get_huggingface_key(),
     }
 
     trading_days = get_trading_days(args.ticker, start_date, end_date)

--- a/config.py
+++ b/config.py
@@ -45,16 +45,3 @@ def get_finnhub_key(env_path: Optional[str] = None) -> str:
     if not key:
         raise ValueError('FINNHUB_API_KEY not found in environment')
     return key
-
-
-@lru_cache()
-def get_huggingface_key(env_path: Optional[str] = None) -> str:
-    """Load Hugging Face API key from .env file."""
-    env_file = env_path or Path(__file__).resolve().parent / '.env'
-    if Path(env_file).exists():
-        load_dotenv(env_file)
-    from os import getenv
-    key = getenv('HUGGINGFACE_API_KEY')
-    if not key:
-        raise ValueError('HUGGINGFACE_API_KEY not found in environment')
-    return key

--- a/data_sources/news_sentiment_fetcher.py
+++ b/data_sources/news_sentiment_fetcher.py
@@ -1,9 +1,11 @@
 import json
 import logging
+import re
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import google.generativeai as genai
 import requests
 
 logger = logging.getLogger(__name__)
@@ -12,8 +14,8 @@ logger = logging.getLogger(__name__)
 class NewsSentimentFetcher:
     """Fetch news and sentiment data.
 
-    Tries Alpha Vantage first and falls back to Finnhub + HuggingFace
-    sentiment analysis when Alpha Vantage fails or returns no data.
+    Tries Alpha Vantage first and falls back to Finnhub + Gemini sentiment
+    analysis when Alpha Vantage fails or returns no data.
     """
 
     def __init__(
@@ -21,55 +23,65 @@ class NewsSentimentFetcher:
         tickers: List[str],
         alpha_key: str,
         finnhub_key: Optional[str] = None,
-        hf_key: Optional[str] = None,
+        gemini_key: Optional[str] = None,
         base_date: Optional[datetime] = None,
         cache_dir: Optional[str] = None,
+        gemini_model: str = "gemini-2.0-flash-lite",
     ):
         self.tickers = tickers
         self.alpha_key = alpha_key
         self.finnhub_key = finnhub_key
-        self.hf_key = hf_key
         self.base_date = base_date or datetime.utcnow()
         self.cache_dir = Path(cache_dir or "data/news_sentiment")
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def _analyze_text(self, text: str) -> Dict[str, Any]:
-        """Return sentiment score and label for text using HuggingFace."""
-        if not self.hf_key:
-            return {"overall_sentiment_score": 0.0, "overall_sentiment_label": "neutral"}
-        try:
-            headers = {"Authorization": f"Bearer {self.hf_key}"}
-            resp = requests.post(
-                "https://router.huggingface.co/hf-inference/models/ProsusAI/finbert",
+        self.gemini_model_name = gemini_model
+        self._gemini: Optional[genai.GenerativeModel] = None
+        if gemini_key:
+            genai.configure(api_key=gemini_key)
+            self._gemini = genai.GenerativeModel(gemini_model)
 
-                headers=headers,
-                json={"inputs": text},
-                timeout=10,
-            )
-            resp.raise_for_status()
-            result = resp.json()
-            pos = neg = 0.0
-            top_label = "neutral"
-            top_score = 0.0
-            for item in result:
-                label = item.get("label", "").lower()
-                score = float(item.get("score", 0.0))
-                if label == "positive":
-                    pos = score
-                elif label == "negative":
-                    neg = score
-                if score > top_score:
-                    top_score = score
-                    top_label = label
-            overall = pos - neg
+    def _analyze_text(self, text: str) -> Dict[str, Any]:
+        """Return sentiment score and label for text using Gemini."""
+        if not self._gemini:
+            raise ValueError("Gemini API key not configured")
+
+        prompt = (
+            "Classify the sentiment of the following news headline as positive, negative, or "
+            "neutral. Respond with JSON containing keys label and score (between -1 and 1).\n"
+            f"Headline: {text}"
+        )
+        try:
+            resp = self._gemini.generate_content(prompt)
+            logger.debug("Gemini raw response: %s", getattr(resp, "text", resp))
+            data = self._parse_gemini_json(resp.text)
+            label = str(data.get("label", "neutral")).lower()
+            score = float(data.get("score", 0.0))
             return {
-                "overall_sentiment_score": overall,
-                "overall_sentiment_label": top_label,
+                "overall_sentiment_score": score,
+                "overall_sentiment_label": label,
                 "relevance_score": 1.0,
             }
-        except Exception:
-            logger.exception("HuggingFace sentiment analysis failed")
-            return {"overall_sentiment_score": 0.0, "overall_sentiment_label": "neutral", "relevance_score": 1.0}
+        except Exception as exc:
+            logger.exception("Gemini sentiment analysis failed: %s", exc)
+            raise
+
+    @staticmethod
+    def _parse_gemini_json(text: str) -> Dict[str, Any]:
+        """Extract and parse a JSON object from Gemini response text."""
+        if not text:
+            raise ValueError("Empty Gemini response")
+        # Strip Markdown code fences like ```json ... ```
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.strip("`")
+            # remove optional language hint e.g. json
+            cleaned = cleaned.split(None, 1)[-1] if " " in cleaned else cleaned
+        # Find first JSON object in text
+        match = re.search(r"\{.*\}", cleaned, re.S)
+        if not match:
+            raise ValueError("No JSON object found in Gemini response")
+        return json.loads(match.group())
 
     def _fetch_alpha(self, ticker_str: str) -> List[Dict[str, Any]]:
         time_from = (self.base_date - timedelta(days=1)).strftime("%Y%m%dT%H%M")
@@ -92,7 +104,7 @@ class NewsSentimentFetcher:
 
     def _fetch_finnhub(self, ticker_str: str) -> List[Dict[str, Any]]:
         if not self.finnhub_key:
-            return []
+            raise ValueError("Finnhub API key not configured")
         frm = (self.base_date - timedelta(days=1)).strftime("%Y-%m-%d")
         to = self.base_date.strftime("%Y-%m-%d")
         params = {
@@ -101,9 +113,17 @@ class NewsSentimentFetcher:
             "to": to,
             "token": self.finnhub_key,
         }
-        resp = requests.get("https://finnhub.io/api/v1/company-news", params=params, timeout=10)
-        resp.raise_for_status()
-        articles = resp.json()[:50]
+        try:
+            resp = requests.get("https://finnhub.io/api/v1/company-news", params=params, timeout=10)
+            resp.raise_for_status()
+            articles = resp.json()[:50]
+        except Exception as exc:
+            logger.exception("Finnhub request failed: %s", exc)
+            raise
+
+        if not articles:
+            raise ValueError("Empty Finnhub news feed")
+
         feed: List[Dict[str, Any]] = []
         for art in articles:
             title = art.get("headline")
@@ -111,6 +131,8 @@ class NewsSentimentFetcher:
                 continue
             sentiment = self._analyze_text(title)
             feed.append({"title": title, **sentiment})
+        if not feed:
+            raise ValueError("No analyzable Finnhub articles")
         return feed
 
     def fetch(self) -> List[Dict[str, Any]]:
@@ -127,9 +149,16 @@ class NewsSentimentFetcher:
         try:
             logger.info("Fetching news sentiment for %s via Alpha Vantage", ticker_str)
             feed = self._fetch_alpha(ticker_str)
+            logger.info("News sentiment fetched from Alpha Vantage")
         except Exception as e:
             logger.warning("Alpha Vantage failed: %s", e)
-            feed = self._fetch_finnhub(ticker_str)
+            logger.info("Fetching news sentiment for %s via Finnhub + Gemini", ticker_str)
+            try:
+                feed = self._fetch_finnhub(ticker_str)
+                logger.info("News sentiment fetched from Finnhub + Gemini")
+            except Exception as exc:
+                logger.exception("Finnhub + Gemini failed: %s", exc)
+                raise
 
         try:
             cache_file.write_text(json.dumps(feed))

--- a/run_agent.py
+++ b/run_agent.py
@@ -23,7 +23,6 @@ from config import (
     get_api_key,
     get_alpha_vantage_key,
     get_finnhub_key,
-    get_huggingface_key,
 )
 
 
@@ -47,12 +46,11 @@ def build_graph(
     gemini_key: str,
     alpha_key: str,
     finnhub_key: str,
-    hf_key: str,
     base_date: datetime,
 ):
     fetcher = StockDataFetcher([ticker], end_date=base_date)
     news_fetcher = NewsSentimentFetcher(
-        [ticker], alpha_key, finnhub_key, hf_key, base_date=base_date, cache_dir="data/news_sentiment"
+        [ticker], alpha_key, finnhub_key, gemini_key, base_date=base_date, cache_dir="data/news_sentiment"
     )
     insider_fetcher = InsiderDataFetcher(ticker, finnhub_key, base_date=base_date)
     peer_fetcher = PeerDataFetcher(ticker, finnhub_key, alpha_key, base_date=base_date)
@@ -186,13 +184,12 @@ def main():
     gemini_key = get_api_key()
     alpha_key = get_alpha_vantage_key()
     finnhub_key = get_finnhub_key()
-    hf_key = get_huggingface_key()
     base_date = (
         datetime.strptime(args.date, "%Y-%m-%d")
         if args.date
         else datetime.now(timezone.utc)
     )
-    graph = build_graph(args.ticker, gemini_key, alpha_key, finnhub_key, hf_key, base_date)
+    graph = build_graph(args.ticker, gemini_key, alpha_key, finnhub_key, base_date)
     result = graph.invoke({})
     print("\nFinal decision:", result["decision"])
 

--- a/tests/test_news_sentiment_parser.py
+++ b/tests/test_news_sentiment_parser.py
@@ -1,0 +1,20 @@
+import pytest
+from data_sources.news_sentiment_fetcher import NewsSentimentFetcher
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (
+            "```json\n{\"label\": \"positive\", \"score\": 0.8}\n```",
+            {"label": "positive", "score": 0.8},
+        ),
+        (
+            "Some text before {\"label\": \"negative\", \"score\": -0.5} and after",
+            {"label": "negative", "score": -0.5},
+        ),
+    ],
+)
+def test_parse_gemini_json(raw, expected):
+    data = NewsSentimentFetcher._parse_gemini_json(raw)
+    assert data == expected


### PR DESCRIPTION
## Summary
- Replace HuggingFace FinBERT fallback with Gemini 2.0-flash-lite in news sentiment fetcher
- Log whether news sentiment comes from Alpha Vantage or Finnhub + Gemini and halt on failures
- Remove HuggingFace configuration and update docs/scripts accordingly
- Handle Gemini responses wrapped in code blocks or extra text to avoid JSON parse errors
- Test Gemini JSON parsing helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689673ba7bd0832abdd36b0c5c6f2d78